### PR TITLE
Improve installer with opencoarrays workaround

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -89,7 +89,8 @@ FPM_FLAG=" $FPM_FLAG -L$NETCDF_LIB_PATH -L$FFTW_LIB_PATH -L$HDF5_LIB_PATH"
 FPM_FC="caf"
 FPM_CC="$CC"
 
-PKG_CONFIG_PATH="$PREFIX"/lib/pkgconfig
+export PKG_CONFIG_PATH="$PREFIX"/lib/pkgconfig
+
 if [ ! -d $PKG_CONFIG_PATH ]; then
   mkdir -p $PKG_CONFIG_PATH
 fi
@@ -107,6 +108,7 @@ cd -
 cd build
   echo "#!/bin/sh"                                                    >  run-fpm.sh
   echo "#-- DO NOT EDIT -- created by icar/install.sh"                >> run-fpm.sh
+  echo "export PKG_CONFIG_PATH"                                       >> run-fpm.sh
   echo "\"${PREFIX}\"/bin/fpm \$@ \\"                                 >> run-fpm.sh
   echo "--profile debug \\"                                           >> run-fpm.sh
   echo "--c-compiler \"`pkg-config icar --variable=ICAR_FPM_CC`\" \\" >> run-fpm.sh

--- a/install.sh
+++ b/install.sh
@@ -73,7 +73,8 @@ cd build/dependencies/netcdf-fortran/build
   cmake .. \
     -DNETCDF_C_LIBRARY="$NETCDF_PREFIX/lib" \
     -DNETCDF_C_INCLUDE_DIR="$NETCDF_PREFIX/include"
-  sudo make -j4 install
+  make -j4
+  sudo make install
 cd -
 
 GIT_VERSION=`git describe --long --dirty --all --always | sed -e's/heads\///'`
@@ -110,7 +111,7 @@ cd build
   echo "#!/bin/sh"                                                    >  run-fpm.sh
   echo "#-- DO NOT EDIT -- created by icar/install.sh"                >> run-fpm.sh
   echo "export PKG_CONFIG_PATH"                                       >> run-fpm.sh
-  echo "\"${PREFIX}\"/bin/fpm \$@ \\"                                 >> run-fpm.sh
+  echo "`brew --prefix fpm`/bin/fpm \$@ --verbose \\"                       >> run-fpm.sh
   echo "--profile debug \\"                                           >> run-fpm.sh
   echo "--c-compiler \"`pkg-config icar --variable=ICAR_FPM_CC`\" \\" >> run-fpm.sh
   echo "--compiler \"`pkg-config icar --variable=ICAR_FPM_FC`\" \\"   >> run-fpm.sh

--- a/install.sh
+++ b/install.sh
@@ -55,7 +55,8 @@ if ! command -v brew > /dev/null ; then
 fi
 
 GCC_VER="12"
-brew install cmake netcdf fftw gcc@$GCC_VER pkg-config coreutils # coreutils supports `realpath` below
+brew tap fortran-lang/fortran
+brew install fpm cmake netcdf fftw gcc@$GCC_VER pkg-config coreutils # coreutils supports `realpath` below
 
 PREFIX=`realpath $PREFIX`
 

--- a/install.sh
+++ b/install.sh
@@ -59,33 +59,6 @@ brew install cmake netcdf fftw gcc@$GCC_VER pkg-config coreutils # coreutils sup
 
 PREFIX=`realpath $PREFIX`
 
-# Define the sudo command to be used if the installation path requires administrative permissions
-set_SUDO_if_needed_to_write_to_directory()
-{
-  directory_to_create=$1
-  SUDO_IF_NECESSARY=""
-  echo "Checking whether the directory ${directory_to_create} exists... "
-  if [ -d "${directory_to_create}" ]; then
-    echo "yes"
-    echo "Checking whether I have write permissions to ${directory_to_create} ... "
-    if [ -w "${directory_to_create}" ]; then
-      echo "yes"
-    else
-      echo "no"
-      SUDO_IF_NECESSARY="sudo"
-    fi
-  else
-    echo "no"
-    echo "Checking whether I can create ${directory_to_create} ... "
-    if mkdir -p "${directory_to_create}" >& /dev/null; then
-      echo "yes."
-    else
-      echo "no."
-      SUDO_IF_NECESSARY="sudo"
-    fi
-  fi
-}
-
 mkdir -p build/dependencies
 if [ -d ./build/dependencies/netcdf-fortran ]; then
   rm -rf ./build/dependencies/netcdf-fortran
@@ -100,7 +73,7 @@ cd build/dependencies/netcdf-fortran/build
     -DNETCDF_C_LIBRARY="$NETCDF_PREFIX/lib" \
     -DNETCDF_C_INCLUDE_DIR="$NETCDF_PREFIX/include"
   set_SUDO_if_needed_to_write_to_directory "$NETCDF_PREFIX"
-  $SUDO_IF_NECESSARY make -j4 install
+  sudo make -j4 install
 cd -
 
 GIT_VERSION=`git describe --long --dirty --all --always | sed -e's/heads\///'`

--- a/install.sh
+++ b/install.sh
@@ -54,9 +54,9 @@ if ! command -v brew > /dev/null ; then
   fi
 fi
 
-GCC_VER="12"
-brew tap fortran-lang/fortran
-brew install fpm cmake netcdf fftw gcc@$GCC_VER pkg-config coreutils # coreutils supports `realpath` below
+
+brew tap fortran-lang/fortran # required for building fpm
+brew install fpm opencoarrays cmake netcdf fftw pkg-config coreutils # coreutils supports `realpath` below
 
 PREFIX=`realpath $PREFIX`
 
@@ -68,6 +68,7 @@ git clone https://github.com/Unidata/netcdf-fortran.git build/dependencies/netcd
 mkdir -p build/dependencies/netcdf-fortran/build
 
 cd build/dependencies/netcdf-fortran/build
+  GCC_VER="12" # This should be replaced with code extracting the version number from Homebrew
   export FC=gfortran-${GCC_VER} CC=gcc-${GCC_VER} CXX=g++-${GCC_VER}
   NETCDF_PREFIX="`brew --prefix netcdf`"
   cmake .. \

--- a/install.sh
+++ b/install.sh
@@ -115,6 +115,7 @@ cd build
   chmod u+x run-fpm.sh
 cd -
 
+export PKG_CONFIG_PATH
 ./build/run-fpm.sh test
 
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -80,7 +80,6 @@ FFTW_INCLUDE_PATH="`brew --prefix fftw`/include"
 NETCDF_LIB_PATH="`brew --prefix netcdf`/lib"
 HDF5_LIB_PATH="`brew --prefix hdf5`/lib"
 FFTW_LIB_PATH="`brew --prefix fftw`/lib"
-export PKG_CONFIG_PATH="$PREFIX"/lib/pkgconfig
 
 FPM_FLAG="-cpp -DUSE_ASSERTIONS=.true."
 FPM_FLAG=" $FPM_FLAG -I$FFTW_INCLUDE_PATH"
@@ -90,6 +89,10 @@ FPM_FLAG=" $FPM_FLAG -L$NETCDF_LIB_PATH -L$FFTW_LIB_PATH -L$HDF5_LIB_PATH"
 FPM_FC="caf"
 FPM_CC="$CC"
 
+PKG_CONFIG_PATH="$PREFIX"/lib/pkgconfig
+if [ ! -d $PKG_CONFIG_PATH ]; then
+  mkdir -p $PKG_CONFIG_PATH
+fi
 cd "$PKG_CONFIG_PATH"
   echo "ICAR_FPM_CXX=\"$CXX\""       >  icar.pc
   echo "ICAR_FPM_CC=\"$FPM_CC\""     >> icar.pc

--- a/install.sh
+++ b/install.sh
@@ -72,7 +72,6 @@ cd build/dependencies/netcdf-fortran/build
   cmake .. \
     -DNETCDF_C_LIBRARY="$NETCDF_PREFIX/lib" \
     -DNETCDF_C_INCLUDE_DIR="$NETCDF_PREFIX/include"
-  set_SUDO_if_needed_to_write_to_directory "$NETCDF_PREFIX"
   sudo make -j4 install
 cd -
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/bin/sh
 
 set -e # exit on error
 
@@ -64,7 +64,7 @@ set_SUDO_if_needed_to_write_to_directory()
 {
   directory_to_create=$1
   SUDO_IF_NECESSARY=""
-  ehcho "Checking whether the directory ${directory_to_create} exists... "
+  echo "Checking whether the directory ${directory_to_create} exists... "
   if [ -d "${directory_to_create}" ]; then
     echo "yes"
     echo "Checking whether I have write permissions to ${directory_to_create} ... "
@@ -87,8 +87,12 @@ set_SUDO_if_needed_to_write_to_directory()
 }
 
 mkdir -p build/dependencies
+if [ -d ./build/dependencies/netcdf-fortran ]; then
+  rm -rf ./build/dependencies/netcdf-fortran
+fi
 git clone https://github.com/Unidata/netcdf-fortran.git build/dependencies/netcdf-fortran
 mkdir -p build/dependencies/netcdf-fortran/build
+
 cd build/dependencies/netcdf-fortran/build
   export FC=gfortran-${GCC_VER} CC=gcc-${GCC_VER} CXX=g++-${GCC_VER}
   NETCDF_PREFIX="`brew --prefix netcdf`"

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,8 @@ fi
 
 
 brew tap fortran-lang/fortran # required for building fpm
-brew install fpm opencoarrays cmake netcdf fftw pkg-config coreutils # coreutils supports `realpath` below
+brew install fpm cmake netcdf fftw pkg-config coreutils # coreutils supports `realpath` below
+brew install --build-from-source opencoarrays # installs opencoarrays from the installer rather than through homebrew
 
 PREFIX=`realpath $PREFIX`
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: installer, opencoarrays, open-mpi, dependency, sync, homebrew, source, workaround

SOURCE: Jordan Welsman: Berkeley Lab

DESCRIPTION OF CHANGES: As described in opencoarrays Issue #110650, when opencoarrays installation is out of sync with the open-mpi dependency version there is an error produced when installing opencoarrays with homebrew via the ICAR installer.

This pull request fixes the issue by adding a line of code which acts as a workaround by installing opencoarrays from source rather than through homebrew..

ISSUE: opencoarrays Issue #110650

TESTS CONDUCTED: Fix was tested by running both before and after opencoarrays was uninstalled with homebrew prior to running the install script.

### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
_Uses workaround suggested in opencoarrays Issue #110650._
 - [ ] Tests added (unit tests and/or regression/integration tests)
 _Tests not needed for code added._
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 _Does not need new files._
 - [X] Fully documented
